### PR TITLE
Add configurable tvOS web wrapper boilerplate

### DIFF
--- a/tvos-url-loader/README.md
+++ b/tvos-url-loader/README.md
@@ -1,0 +1,50 @@
+# tvOS URL Loader Boilerplate
+
+A minimal SwiftUI tvOS application that wraps a configurable `WKWebView`. The app loads the URL defined in `AppConfig.swift`, so you can ship multiple white-label builds by changing a single value.
+
+## Project structure
+
+```
+tvos-url-loader/
+├── README.md
+├── URLDash.xcodeproj
+└── URLDash/
+    ├── AppConfig.swift
+    ├── ContentView.swift
+    ├── Info.plist
+    ├── URLDashApp.swift
+    ├── WebView.swift
+    ├── Assets.xcassets/
+    │   └── Contents.json
+    └── Preview Content/
+        └── Preview Assets.xcassets/
+            └── Contents.json
+```
+
+Open `URLDash.xcodeproj` in Xcode 15 or newer to build and run the project on tvOS.
+
+## Configure the destination URL
+
+The only place you need to update to ship a differently branded app is [`AppConfig.swift`](URLDash/AppConfig.swift):
+
+```swift
+static let urlString = "https://example.com"
+```
+
+Set the value to the fully-qualified URL you want to present. The helper computed property validates the value at launch and will crash in debug builds if the string is not a valid URL, making mistakes easier to spot early.
+
+## Releasing multiple white-label builds
+
+1. Duplicate the project directory for each brand or environment.
+2. Update `urlString` in `AppConfig.swift` to point at the correct endpoint.
+3. Optionally customise the bundle identifier in the *Signing & Capabilities* section of the target settings.
+4. Provide brand-specific app icons and top shelf images by adding an `AppIcon.brandassets` catalog under `Assets.xcassets` before submitting to the App Store.
+
+Because the rest of the application is generic, no other code changes are required to publish additional builds.
+
+## Notes
+
+- The deployment target is tvOS 17.0 (adjust in the target build settings if you need a different minimum version).
+- The embedded web view enables inline media playback and sets a tvOS-friendly user agent string.
+- Error and loading states are surfaced with simple SwiftUI overlays so viewers understand what is happening.
+- If the target site requires non-HTTPS content, add the appropriate [App Transport Security exceptions](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) to `Info.plist`.

--- a/tvos-url-loader/URLDash.xcodeproj/project.pbxproj
+++ b/tvos-url-loader/URLDash.xcodeproj/project.pbxproj
@@ -1,0 +1,331 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+A10101010101010101010101 /* URLDashApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20101010101010101010101 /* URLDashApp.swift */; };
+A10101010101010101010102 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20101010101010101010102 /* ContentView.swift */; };
+A10101010101010101010103 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20101010101010101010103 /* WebView.swift */; };
+A10101010101010101010104 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20101010101010101010104 /* AppConfig.swift */; };
+A10101010101010101010105 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20101010101010101010105 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+A20101010101010101010101 /* URLDashApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDashApp.swift; sourceTree = "<group>"; };
+A20101010101010101010102 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+A20101010101010101010103 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+A20101010101010101010104 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
+A20101010101010101010105 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+A20101010101010101010106 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+A20101010101010101010107 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+A20101010101010101010108 /* URLDash.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = URLDash.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+A30101010101010101010100 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+A40101010101010101010100 = {
+isa = PBXGroup;
+children = (
+A50101010101010101010100 /* URLDash */,
+A60101010101010101010100 /* Products */,
+);
+sourceTree = "<group>";
+};
+A50101010101010101010100 /* URLDash */ = {
+isa = PBXGroup;
+children = (
+A20101010101010101010101 /* URLDashApp.swift */,
+A20101010101010101010104 /* AppConfig.swift */,
+A20101010101010101010102 /* ContentView.swift */,
+A20101010101010101010103 /* WebView.swift */,
+A20101010101010101010105 /* Assets.xcassets */,
+A20101010101010101010106 /* Info.plist */,
+A70101010101010101010100 /* Preview Content */,
+);
+path = URLDash;
+sourceTree = "<group>";
+};
+A60101010101010101010100 /* Products */ = {
+isa = PBXGroup;
+children = (
+A20101010101010101010108 /* URLDash.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+A70101010101010101010100 /* Preview Content */ = {
+isa = PBXGroup;
+children = (
+A20101010101010101010107 /* Preview Assets.xcassets */,
+);
+path = "Preview Content";
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+A80101010101010101010100 /* URLDash */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = A90101010101010101010100 /* Build configuration list for PBXNativeTarget "URLDash" */;
+buildPhases = (
+B00101010101010101010100 /* Sources */,
+A30101010101010101010100 /* Frameworks */,
+B10101010101010101010100 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = URLDash;
+productName = URLDash;
+productReference = A20101010101010101010108 /* URLDash.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+AA0101010101010101010100 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+LastSwiftUpdateCheck = 1550;
+LastUpgradeCheck = 1550;
+TargetAttributes = {
+A80101010101010101010100 = {
+CreatedOnToolsVersion = 15.5;
+};
+};
+};
+buildConfigurationList = AB0101010101010101010100 /* Build configuration list for PBXProject "URLDash" */;
+compatibilityVersion = "Xcode 15.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = A40101010101010101010100;
+productRefGroup = A60101010101010101010100 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+A80101010101010101010100 /* URLDash */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+B10101010101010101010100 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+A10101010101010101010105 /* Assets.xcassets in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+B00101010101010101010100 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+A10101010101010101010104 /* AppConfig.swift in Sources */,
+A10101010101010101010102 /* ContentView.swift in Sources */,
+A10101010101010101010103 /* WebView.swift in Sources */,
+A10101010101010101010101 /* URLDashApp.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+AC0101010101010101010100 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_NS_ASSERTIONS = YES;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SDKROOT = appletvos;
+SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+TARGETED_DEVICE_FAMILY = 3;
+TVOS_DEPLOYMENT_TARGET = 17.0;
+};
+name = Debug;
+};
+AD0101010101010101010100 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+MTL_ENABLE_DEBUG_INFO = NO;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SDKROOT = appletvos;
+SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+TARGETED_DEVICE_FAMILY = 3;
+TVOS_DEPLOYMENT_TARGET = 17.0;
+};
+name = Release;
+};
+AE0101010101010101010100 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = "";
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+CLANG_ENABLE_MODULES = YES;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = URLDash/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = "com.example.tvurl";
+PRODUCT_NAME = "$(TARGET_NAME)";
+SDKROOT = appletvos;
+SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = 3;
+TVOS_DEPLOYMENT_TARGET = 17.0;
+};
+name = Debug;
+};
+AF0101010101010101010100 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = "";
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+CLANG_ENABLE_MODULES = YES;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = URLDash/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = "com.example.tvurl";
+PRODUCT_NAME = "$(TARGET_NAME)";
+SDKROOT = appletvos;
+SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = 3;
+TVOS_DEPLOYMENT_TARGET = 17.0;
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+AB0101010101010101010100 /* Build configuration list for PBXProject "URLDash" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AC0101010101010101010100 /* Debug */,
+AD0101010101010101010100 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+A90101010101010101010100 /* Build configuration list for PBXNativeTarget "URLDash" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AE0101010101010101010100 /* Debug */,
+AF0101010101010101010100 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+
+};
+rootObject = AA0101010101010101010100 /* Project object */;
+}

--- a/tvos-url-loader/URLDash/AppConfig.swift
+++ b/tvos-url-loader/URLDash/AppConfig.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Global configuration values for the tvOS web container app.
+enum AppConfig {
+    /// The single source of truth for the URL that should be loaded by the app.
+    ///
+    /// Update this value when you want to ship the same binary with a different
+    /// destination. Keeping it in one place makes it easy to maintain multiple
+    /// branded variants of the application.
+    static let urlString = "https://example.com"
+
+    /// A validated URL generated from ``urlString``.
+    static var appURL: URL {
+        guard let url = URL(string: urlString) else {
+            preconditionFailure("Invalid URL string: \(urlString)")
+        }
+        return url
+    }
+}

--- a/tvos-url-loader/URLDash/Assets.xcassets/Contents.json
+++ b/tvos-url-loader/URLDash/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/tvos-url-loader/URLDash/ContentView.swift
+++ b/tvos-url-loader/URLDash/ContentView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var isLoading = true
+    @State private var error: WebView.WebError?
+    @State private var reloadToken = UUID()
+
+    var body: some View {
+        ZStack {
+            WebView(url: AppConfig.appURL, reloadID: reloadToken, isLoading: $isLoading, error: $error)
+                .opacity(error == nil ? 1 : 0.2)
+                .background(Color.black)
+
+            if isLoading {
+                ProgressView("Loading…")
+                    .progressViewStyle(.circular)
+                    .padding(32)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 32, style: .continuous))
+                    .transition(.opacity)
+            }
+
+            if let error {
+                VStack(spacing: 24) {
+                    Image(systemName: "wifi.exclamationmark")
+                        .font(.system(size: 96, weight: .regular))
+                    Text(error.title)
+                        .font(.title2).bold()
+                    Text(error.message)
+                        .multilineTextAlignment(.center)
+                        .font(.body)
+                        .frame(maxWidth: 600)
+                    Button("Retry") {
+                        isLoading = true
+                        self.error = nil
+                        reloadToken = UUID()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 40, style: .continuous))
+                .padding()
+            }
+        }
+        .background(Color.black.ignoresSafeArea())
+        .animation(.easeInOut, value: isLoading)
+        .animation(.easeInOut, value: error?.id)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/tvos-url-loader/URLDash/Info.plist
+++ b/tvos-url-loader/URLDash/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDevelopmentRegion</key>
+<string>$(DEVELOPMENT_LANGUAGE)</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleName</key>
+<string>$(PRODUCT_NAME)</string>
+<key>CFBundlePackageType</key>
+<string>APPL</string>
+<key>CFBundleShortVersionString</key>
+<string>1.0</string>
+<key>CFBundleVersion</key>
+<string>1</string>
+<key>LSRequiresIPhoneOS</key>
+<true/>
+<key>UILaunchScreen</key>
+<dict/>
+<key>UISupportedInterfaceOrientations</key>
+<array>
+<string>UIInterfaceOrientationLandscapeLeft</string>
+<string>UIInterfaceOrientationLandscapeRight</string>
+</array>
+<key>WKAppBoundDomains</key>
+<array/>
+</dict>
+</plist>

--- a/tvos-url-loader/URLDash/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/tvos-url-loader/URLDash/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/tvos-url-loader/URLDash/URLDashApp.swift
+++ b/tvos-url-loader/URLDash/URLDashApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct URLDashApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/tvos-url-loader/URLDash/WebView.swift
+++ b/tvos-url-loader/URLDash/WebView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    let url: URL
+    let reloadID: UUID
+    @Binding var isLoading: Bool
+    @Binding var error: WebError?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.allowsInlineMediaPlayback = true
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        context.coordinator.configure(webView)
+        context.coordinator.load(url, on: webView, reloadID: reloadID)
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        context.coordinator.parent = self
+        if context.coordinator.lastLoadedURL != url || context.coordinator.lastReloadID != reloadID {
+            context.coordinator.load(url, on: uiView, reloadID: reloadID)
+        }
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: WebView
+        var lastLoadedURL: URL?
+        var lastReloadID: UUID?
+
+        init(parent: WebView) {
+            self.parent = parent
+        }
+
+        func configure(_ webView: WKWebView) {
+            webView.navigationDelegate = self
+            webView.allowsBackForwardNavigationGestures = false
+            webView.scrollView.contentInsetAdjustmentBehavior = .never
+            webView.scrollView.bounces = false
+            webView.isOpaque = false
+            webView.backgroundColor = .black
+            webView.scrollView.backgroundColor = .black
+        }
+
+        func load(_ url: URL, on webView: WKWebView, reloadID: UUID) {
+            lastLoadedURL = url
+            lastReloadID = reloadID
+
+            var request = URLRequest(url: url)
+            request.cachePolicy = .reloadRevalidatingCacheData
+            request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+
+            parent.error = nil
+            parent.isLoading = true
+            webView.load(request)
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            parent.isLoading = true
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            parent.isLoading = false
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            handle(error)
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            handle(error)
+        }
+
+        private func handle(_ error: Error) {
+            parent.isLoading = false
+            parent.error = WebView.WebError(error: error)
+        }
+
+        private static let userAgent = "Mozilla/5.0 (AppleTV; U; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+    }
+
+    struct WebError: Identifiable, Equatable {
+        let id = UUID()
+        let title: String
+        let message: String
+
+        init(title: String = "Unable to Load", message: String) {
+            self.title = title
+            self.message = message
+        }
+
+        init(error: Error) {
+            self.init(message: error.localizedDescription)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI tvOS app template that loads a configurable URL via WKWebView
- centralise the destination URL in AppConfig.swift so multiple white-label builds can be produced by changing one value
- include loading and error handling UI plus project documentation for configuring the boilerplate

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce5a00ffb88325b9642a42212d81fc